### PR TITLE
SITES-124: Fix edge case where user deletes a field from a bundle

### DIFF
--- a/sar.drush.inc
+++ b/sar.drush.inc
@@ -410,9 +410,10 @@ function _drush_sar_replace_d7($options) {
       // does not exist on the bundles specified, just skip to the next field.
       if (!empty($options['bundles'])) {
         $bundles = array_intersect($options['bundles'], $bundles);
-        if (empty($bundles)) {
-          continue;
-        }
+      }
+
+      if (empty($bundles)) {
+        continue;
       }
 
       // At this stage, $bundles contains either the full list of bundles for


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fix edge case where user deletes a field from a bundle

# Needed By (Date)
- Not super pressing, I can use this fork in the meantime

# Criticality
- 3

# Steps to Test

1. Clone people.stanford.edu/jaaker to local
2. Run `drush sar -y "https://people.stanford.edu/jaaker/ "/"`
3. Sob quietly at PDO exception error
4. Check out this branch
5. Repeat steps 1-2
6. Rejoice in satisfaction

I'm pretty sure moving this conditional out from being nested in the other conditional shouldn't cause any problems.

# Affected Projects or Products
- Sites 2.0 migration

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SITES-124
