### PR TITLE
SITES-124: Allow to replace with empty strings

### DIFF
--- a/sar.drush.inc
+++ b/sar.drush.inc
@@ -229,7 +229,7 @@ function drush_sar_parse_options() {
 
   // The other CLI args.
   $args = drush_get_arguments();
-  if (count($args) < 3) {
+  if (count($args) < 2) {
     $error[] = dt('You need to specify both a string to search and one to replace.');
   }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- When you pass an empty string (`drush sar "https://people.stanford.edu/jbickar/" ""`), SAR complains "You need to specify both a string to search and one to replace." In this case, `$args[2]` is not getting populated. I think we can get away with this change, because in line 245, we're checking if `$args[2]` is empty and setting it to "" if it is. This is needed because menu items cannot start with `/` (Drupal 7 will complain).

```
  $replace = $args[2];
  if (empty($args[2])) {
    $replace = "";
  }
```

# Needed By (Date)
- Whenever

# Criticality
- 3

# Steps to Test

1. Check out this branch
2. Create a menu item with the URL "http://example.dev/path/to/item"
3. Run `drush sarm "http://example.dev/" ""`
4. See that your menu item is now `path/to/item`
5. Try the same thing with a link and `drush sarl`

# Affected Projects or Products
- Sites 2.0

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SITES-124
