### PR TITLE
SITES-481 and SITES-482: Add support for Views and JS Injector

### DIFF
--- a/sar.drush.inc
+++ b/sar.drush.inc
@@ -482,7 +482,7 @@ function _drush_sar_replace_views($options) {
   $result = db_query('SELECT vid,id,display_options FROM {views_display} vd');
   foreach ($result as $record) {
     // Unserialize the `display_options` column to get it into an array.
-    $display_options = unserialize(($record->display_options));
+    $display_options = unserialize($record->display_options);
     // Track the original.
     $display_options_orig = $display_options;
     // Format our search and replace strings for preg_replace(). Use preg_quote() to escape forward slashes like sites.stanford.edu/foo.

--- a/sar.drush.inc
+++ b/sar.drush.inc
@@ -492,8 +492,6 @@ function _drush_sar_replace_views($options) {
     }
     $search = '/' . $search . '/';
     $replace = $options['replace'];
-    var_dump($search);
-    var_dump($replace);
     $display_options['footer']['area']['content'] = preg_replace($search, $replace, $display_options['footer']['area']['content']);
     $display_options['header']['area']['content'] = preg_replace($search, $replace, $display_options['header']['area']['content']);
     // Only run the DB query if we have changed the options.

--- a/sar.drush.inc
+++ b/sar.drush.inc
@@ -81,7 +81,26 @@ function sar_drush_command() {
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_FULL,
   );
 
-  return $items;
+    // For Views.
+    $items['search-and-replace-views'] = array(
+        'aliases' => array('sarv'),
+        'callback' => 'drush_sar_replace_views',
+        'description' => dt('Replace strings in all Views.'),
+        'options' => array(
+            'regex'    => dt('Use regular expression when searching for a match'),
+        ),
+        'arguments' => array(
+            'search'  => dt('Existing text.'),
+            'replace' => dt('Replacement text.'),
+        ),
+        'examples' => array(
+            'simple'    => dt('drush sarv devel.example.com www.example.com'),
+            'regex'    => dt('drush sarv devel.example.com www.example.com --regex=^https://'),
+        ),
+        'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_FULL,
+    );
+
+    return $items;
 }
 
 /**
@@ -194,6 +213,27 @@ function drush_sar_replace_menu() {
   }
 
   return _drush_sar_replace_menus($options);
+
+}
+
+/**
+ * Command callback function for drush sarv.
+ *
+ * Search and replace all strings in Views.
+ */
+function drush_sar_replace_views() {
+    // Parse our command line options.
+    $options = drush_sar_parse_options();
+
+    // If there's a problem yo I'll solve it...
+    if (!empty($options['error'])) {
+        foreach ($options['error'] as $error) {
+            drush_log($error, 'error');
+        }
+        return 0;
+    }
+
+    return _drush_sar_replace_views($options);
 
 }
 
@@ -371,6 +411,24 @@ function _drush_sar_replace_menus($options) {
   }
 
   echo "Replaced \"" . $options['search'] . "\"  with \"" . $options['replace'] . "\" in: " . implode($menu_names, ", ");
+}
+
+/**
+ * Private function to do a DB REPLACE query on the `views_display` table.
+ *
+ */
+function _drush_sar_replace_views($options) {
+
+        // views_display.
+        $query = db_update("views_display")
+//            ->condition("menu_name", $menu_name)
+            ->expression("display_options", "REPLACE(display_options, :search, :replace)", array(':search' => $options['search'], ':replace' => $options['replace']));
+        if ($options['regex']) {
+            $query->condition("link_path", $options['regex'], "REGEXP");
+        }
+        $result_data = $query->execute();
+
+    echo "Replaced \"" . $options['search'] . "\"  with \"" . $options['replace'] . "\" in all Views.";
 }
 
 /**

--- a/sar.drush.inc
+++ b/sar.drush.inc
@@ -39,7 +39,26 @@ function sar_drush_command() {
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_FULL,
   );
 
-  // For links.
+  // For JS Injector rules.
+  $items['search-and-replace-js-injector'] = array(
+    'aliases' => array('sarjs'),
+    'callback' => 'drush_sar_replace_js_injector',
+    'description' => dt('Replace strings in all JS Injector rules.'),
+    'options' => array(
+      'regex' => dt('Use regular expression when searching for a match'),
+    ),
+    'arguments' => array(
+      'search' => dt('Existing text.'),
+      'replace' => dt('Replacement text.'),
+    ),
+    'examples' => array(
+      'simple' => dt('drush sarjs devel.example.com www.example.com'),
+      'regex' => dt('drush sarjs devel.example.com www.example.com --regex=^https://'),
+    ),
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_FULL,
+  );
+
+    // For links.
   $items['search-and-replace-link'] = array(
     'aliases' => array('sarl'),
     'callback' => 'drush_sar_replace_link',
@@ -81,24 +100,24 @@ function sar_drush_command() {
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_FULL,
   );
 
-    // For Views.
-    $items['search-and-replace-views'] = array(
-        'aliases' => array('sarv'),
-        'callback' => 'drush_sar_replace_views',
-        'description' => dt('Replace strings in all Views.'),
-        'options' => array(
-            'regex'    => dt('Use regular expression when searching for a match'),
-        ),
-        'arguments' => array(
-            'search'  => dt('Existing text.'),
-            'replace' => dt('Replacement text.'),
-        ),
-        'examples' => array(
-            'simple'    => dt('drush sarv devel.example.com www.example.com'),
-            'regex'    => dt('drush sarv devel.example.com www.example.com --regex=^https://'),
-        ),
-        'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_FULL,
-    );
+  // For Views.
+  $items['search-and-replace-views'] = array(
+    'aliases' => array('sarv'),
+    'callback' => 'drush_sar_replace_views',
+    'description' => dt('Replace strings in all Views.'),
+    'options' => array(
+      'regex' => dt('Use regular expression when searching for a match'),
+    ),
+    'arguments' => array(
+      'search' => dt('Existing text.'),
+      'replace' => dt('Replacement text.'),
+    ),
+    'examples' => array(
+      'simple' => dt('drush sarv devel.example.com www.example.com'),
+      'regex' => dt('drush sarv devel.example.com www.example.com --regex=^https://'),
+    ),
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_FULL,
+  );
 
     return $items;
 }
@@ -168,6 +187,27 @@ function drush_sar_replace() {
 }
 
 /**
+ * Command callback function for drush sarj.
+ *
+ * Search and replace all strings in JS Injector rules.
+ */
+function drush_sar_replace_js_injector() {
+  // Parse our command line options.
+  $options = drush_sar_parse_options();
+
+  // If there's a problem yo I'll solve it...
+  if (!empty($options['error'])) {
+    foreach ($options['error'] as $error) {
+      drush_log($error, 'error');
+    }
+    return 0;
+  }
+
+  return _drush_sar_replace_js_injector($options);
+
+}
+
+/**
  * Command callback.
  *
  * This callback checks the version of Drupal it's operating on and runs an
@@ -222,18 +262,18 @@ function drush_sar_replace_menu() {
  * Search and replace all strings in Views.
  */
 function drush_sar_replace_views() {
-    // Parse our command line options.
-    $options = drush_sar_parse_options();
+  // Parse our command line options.
+  $options = drush_sar_parse_options();
 
-    // If there's a problem yo I'll solve it...
-    if (!empty($options['error'])) {
-        foreach ($options['error'] as $error) {
-            drush_log($error, 'error');
-        }
-        return 0;
+  // If there's a problem yo I'll solve it...
+  if (!empty($options['error'])) {
+    foreach ($options['error'] as $error) {
+      drush_log($error, 'error');
     }
+    return 0;
+  }
 
-    return _drush_sar_replace_views($options);
+  return _drush_sar_replace_views($options);
 
 }
 
@@ -308,6 +348,24 @@ function drush_sar_parse_options() {
     'regex' => $regex,
   );
 }
+
+/**
+ * Private function to do a DB REPLACE query on the `js_injector_rule` table.
+ *
+ */
+function _drush_sar_replace_js_injector($options) {
+
+  // views_display.
+  $query = db_update("js_injector_rule")
+    ->expression("js", "REPLACE(js, :search, :replace)", array(':search' => $options['search'], ':replace' => $options['replace']));
+  if ($options['regex']) {
+    $query->condition("link_path", $options['regex'], "REGEXP");
+  }
+  $result_data = $query->execute();
+
+  echo "Replaced \"" . $options['search'] . "\"  with \"" . $options['replace'] . "\" in all JS Injector rules.";
+}
+
 
 /**
  * [_drush_sar_replace_links description]
@@ -419,16 +477,15 @@ function _drush_sar_replace_menus($options) {
  */
 function _drush_sar_replace_views($options) {
 
-        // views_display.
-        $query = db_update("views_display")
-//            ->condition("menu_name", $menu_name)
-            ->expression("display_options", "REPLACE(display_options, :search, :replace)", array(':search' => $options['search'], ':replace' => $options['replace']));
-        if ($options['regex']) {
-            $query->condition("link_path", $options['regex'], "REGEXP");
-        }
-        $result_data = $query->execute();
+  // views_display.
+  $query = db_update("views_display")
+    ->expression("display_options", "REPLACE(display_options, :search, :replace)", array(':search' => $options['search'], ':replace' => $options['replace']));
+  if ($options['regex']) {
+    $query->condition("link_path", $options['regex'], "REGEXP");
+  }
+  $result_data = $query->execute();
 
-    echo "Replaced \"" . $options['search'] . "\"  with \"" . $options['replace'] . "\" in all Views.";
+  echo "Replaced \"" . $options['search'] . "\"  with \"" . $options['replace'] . "\" in all Views.";
 }
 
 /**

--- a/sar.drush.inc
+++ b/sar.drush.inc
@@ -359,11 +359,11 @@ function _drush_sar_replace_js_injector($options) {
   $query = db_update("js_injector_rule")
     ->expression("js", "REPLACE(js, :search, :replace)", array(':search' => $options['search'], ':replace' => $options['replace']));
   if ($options['regex']) {
-    $query->condition("link_path", $options['regex'], "REGEXP");
+    $query->condition("js", $options['regex'], "REGEXP");
   }
   $result_data = $query->execute();
 
-  echo "Replaced \"" . $options['search'] . "\"  with \"" . $options['replace'] . "\" in all JS Injector rules.";
+  drush_log("Replaced \"" . $options['search'] . "\"  with \"" . $options['replace'] . "\" in all JS Injector rules.", "ok");
 }
 
 

--- a/sar.drush.inc
+++ b/sar.drush.inc
@@ -104,17 +104,17 @@ function sar_drush_command() {
   $items['search-and-replace-views'] = array(
     'aliases' => array('sarv'),
     'callback' => 'drush_sar_replace_views',
-    'description' => dt('Replace strings in all Views.'),
-    'options' => array(
-      'regex' => dt('Use regular expression when searching for a match'),
-    ),
+    'description' => dt('Replace strings in all Views. The search and replace strings support regex as used in preg_replace().'),
     'arguments' => array(
       'search' => dt('Existing text.'),
       'replace' => dt('Replacement text.'),
     ),
+    'options' => array(
+      'regex' => dt('Use regular expression when searching for a match'),
+    ),
     'examples' => array(
       'simple' => dt('drush sarv devel.example.com www.example.com'),
-      'regex' => dt('drush sarv devel.example.com www.example.com --regex=^https://'),
+      'regex' => dt('drush sarv --regex "([a-z0-9]).example.com" "\$1.example.org"'),
     ),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_FULL,
   );
@@ -477,15 +477,48 @@ function _drush_sar_replace_menus($options) {
  */
 function _drush_sar_replace_views($options) {
 
-  // views_display.
-  $query = db_update("views_display")
-    ->expression("display_options", "REPLACE(display_options, :search, :replace)", array(':search' => $options['search'], ':replace' => $options['replace']));
-  if ($options['regex']) {
-    $query->condition("link_path", $options['regex'], "REGEXP");
+  $changed = FALSE;
+  // Get our views_display.
+  $result = db_query('SELECT vid,id,display_options FROM {views_display} vd');
+  foreach ($result as $record) {
+    // Unserialize the `display_options` column to get it into an array.
+    $display_options = unserialize(($record->display_options));
+    // Track the original.
+    $display_options_orig = $display_options;
+    // Format our search and replace strings for preg_replace(). Use preg_quote() to escape forward slashes like sites.stanford.edu/foo.
+    $search = preg_quote($options['search'], "/");
+    if ($options['regex']) {
+      $search = $options['search'];
+    }
+    $search = '/' . $search . '/';
+    $replace = $options['replace'];
+    var_dump($search);
+    var_dump($replace);
+    $display_options['footer']['area']['content'] = preg_replace($search, $replace, $display_options['footer']['area']['content']);
+    $display_options['header']['area']['content'] = preg_replace($search, $replace, $display_options['header']['area']['content']);
+    // Only run the DB query if we have changed the options.
+    if ($display_options !== $display_options_orig) {
+      $display_options = serialize($display_options);
+      // The primary keys for the views_display table are vid, id (e.g., 13,default).
+      $vid = $record->vid;
+      $id = $record->id;
+      // "UPDATE views_display SET display_options = $display_options WHERE vid = $vid and id = $id"
+      $num_updated = db_update('views_display')
+        ->fields(array('display_options' => $display_options))
+        ->condition('vid', $vid)
+        ->condition('id', $id)
+        ->execute();
+      $message = t("The display options for vid=@vid and id=@id have been updated.", array('@vid' => $vid, '@id' => $id));
+      drush_log($message, "ok");
+      $changed = TRUE;
+    }
   }
-  $result_data = $query->execute();
-
-  echo "Replaced \"" . $options['search'] . "\"  with \"" . $options['replace'] . "\" in all Views.";
+  if ($changed == TRUE) {
+    drush_log("Replaced \"" . $options['search'] . "\"  with \"" . $options['replace'] . "\" in applicable Views.", "ok");
+  }
+  else {
+    drush_log("sarv could not find the string \"" . $options['search'] . "\" to replace with \"" . $options['replace'] . "\".", "error");
+  }
 }
 
 /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Just what it says on the tin. Note that it only applies to Views headers and footers.

# Needed By (Date)
- Before sprint end (5.17).

# Criticality
- How critical is this PR on a 1-10 scale? 3

# Steps to Test

1. Create a View with some string in the footer (e.g., "sherakama")
2. Create a JS Injector rule with the same string in it (`alert('sherakama');`)
3. Run `drush sarv sherakama jbickar`
4. Run `drush sarv --regex "jbi(c)k(ar)" "\$1\$2"`
5. Run `drush sarjs sherakama jbickar`
6. Run `drush sarjs jbickar sherakama --regex=^alert`
6. Check that the strings have been replaced (the command in Step 4 should have replaced `jbickar` with `car`).

# Affected Projects or Products
- Sites 2.0

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SITES-481
- https://stanfordits.atlassian.net/browse/SITES-482
- https://github.com/SU-SWS/ansible-playbooks/pull/28
- Anyone who should be notified? ( @kbrownell )

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)