### PR TITLE
SITES-570: Prevent fatal error if js_injector_rule table does not exist

### DIFF
--- a/sar.drush.inc
+++ b/sar.drush.inc
@@ -354,7 +354,10 @@ function drush_sar_parse_options() {
  *
  */
 function _drush_sar_replace_js_injector($options) {
-
+  if (!db_table_exists('js_injector_rule')) {
+    drush_log("The 'js_injector_rule' table does not exist. Took no action.", "warning");
+    return;
+  }
   // views_display.
   $query = db_update("js_injector_rule")
     ->expression("js", "REPLACE(js, :search, :replace)", array(':search' => $options['search'], ':replace' => $options['replace']));
@@ -476,7 +479,10 @@ function _drush_sar_replace_menus($options) {
  *
  */
 function _drush_sar_replace_views($options) {
-
+  if (!db_table_exists('views_display')) {
+    drush_log("The 'views_display' table does not exist. Took no action.", "warning");
+    return;
+  }
   $changed = FALSE;
   // Get our views_display.
   $result = db_query('SELECT vid,id,display_options FROM {views_display} vd');


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fix fatal errors with `sarjs` and `sarv` if the DB tables don't exist

# Needed By (Date)
- Soon, preferably.

# Criticality
- How critical is this PR on a 1-10 scale? 3
- Sites that do not have JS Injector enabled (which is likely a lot) will fail to be migrated with a fatal error

# Steps to Test

1. Create a site on local. Do not install JS Injector. Uninstall Views and drop the `views_display` table
2. Run `drush sarjs foo bar`. See fatal error.
3. Run `drush sarjv foo bar`. See fatal error.
4. Check out this branch
5. Run `drush sarjs foo bar`. No fatal error, warning only.
6. Run `drush sarjv foo bar`. No fatal error, warning only.

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules? Sites 2.0

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-570
- Anyone who should be notified? ( @kbrownell )

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)